### PR TITLE
Implemented relative paths in `app.py` and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,92 @@
 # Software Information Studio Team 15
 
-### Group Members
+## Group Members
 
 | Name            | Student Number |
 | --------------- | -------------- |
 | Christopher Le  | 13915285       |
 | Cameron Merrick | 24575007       |
 | Ethan Burgess   | 13934500       |
-| Ramon Tovar     |                |
+| Ramon Tovar     | 12918761       |
 | Kuan Wang       |                |
 | Zheyu Huang     |                |
 
-### Dependencies
+## Dependencies and Setting Up
 
 - [Bun](https://bun.sh/docs/installation)
+- See further requirements in [requirements](backend\requirements.txt)
 
-### Testing
-
-**Running the app:**
-
+### Frontend
 ```bash
 cd frontend
 bun install
 ```
 
-# Setup environment variables
-
-create a .env file and copy the contents of .env.example, replacing the example variables with proper values:
-
-```# .env
-EXPO_PUBLIC_API_URL="YOUR_TUNNELED_URL_GOES_HERE"
-```
-
-# Running on Android:
-
-```
-bun run android
-```
-
-# Running on IOS:
-
-```
-bun run ios
-```
-
-**Running the API:**
-
+### Backend
 ```bash
 cd backend
 python -m venv venv
-source venv/bin/activate
+
+./venv/Scripts/Activate.ps1     # WINDOWS
+source venv/bin/activate        # UNIX
 
 # Install dependencies using pip:
 pip install -r requirements.txt
 
 # Setup environment variables
 cp .env.example .env
-nano .env
 
 # Execute app.py
 python app.py
 ```
-
-**Microsoft Devtunnel Setup**
-
-- It is also recommended to setup `devtunnel` to access the API from your device
-- https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-
-(If you are using vscode you can just forward port 5000, and set the tunnel to be public)
-
-```bash
-devtunnel user login --github
-devtunnel host -p 5000 --allow-anonymous
-```
-
-- Then change the EXPO_PUBLIC_API_URL in the frontend .env
-
 **OpenAI access key**
 
 - Refer to our project discord text channel: apis-datasets-sdk find the pinned message for the secret key value
 - Directory: backend/openAIAPI.py Variable: client = OpenAI(api_key="dummy key") (line 3)
 - Replace 'dummy key' with the secret key found in discord
+
+### Setup environment variables
+
+Prior to setting up environment variables, it is important that you install [Microsoft Devtunnel](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started). This will allow you to open up a port that will later be utilised to pass captured image data through our established API endpoint and to the model and back with a classification.
+
+Upon installing `Microsoft Devtunnel`, you will need to login;
+
+```bash
+devtunnel user login --github # This will take you to login on GitHub
+```
+
+and then generate a **tunneled URL**. Keep in mind that a new URL will be generated every time you start `Microsoft Devtunnel` and you will need to update your environment variables accordingly.
+
+```bash
+devtunnel host -p 5001 --allow-anonymouso
+
+# It should generate a tunneled URL like: https://qw5dpd7j.aue.devtunnels.ms:5001"
+```
+
+Then create a `.env` file in `frontend/` and copy the contents of `.env.example`, replacing the example variables with proper values:
+
+```# .env
+EXPO_PUBLIC_API_URL="YOUR_TUNNELED_URL_GOES_HERE"
+```
+
+## Running the Project
+### Frontend
+
+Run the following code snippet in the command line will in the `frontend/` directory and then with your camera, scan the generated QR code to open the application in `Expo Go`. If you need help setting up `Expo Go`, try this [getting started tutorial](https://docs.expo.dev/tutorial/create-your-first-app/).
+```bash
+cd frontend
+bun expo start -c
+```
+
+### Backend
+
+Run the following code snippet in the command line while in the `backend/` directory:
+```bash
+cd backend
+python app.py
+```
+
+And then in another terminal instance, spin up your `Microsoft Devtunnel` with (remember to update your environment variables in `frontend/.env` with the newly generated URL):
+```bash
+devtunnel host -p 5001 --allow-anonymous
+```

--- a/backend/app.py
+++ b/backend/app.py
@@ -102,4 +102,4 @@ def convert_base64_jpg(base64_string):
 
 
 if __name__ == '__main__':
-    app.run(host="0.0.0.0", port=5001, debug=True)
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -12,14 +12,26 @@ from datetime import datetime
 from openAIAPI import open_ai_response
 import uuid
 from classificationMapping import map_class
+import pathlib
+import warnings
 
 app = Flask(__name__)
 CORS(app)
+MODEL = "best.pth" # Update this as necessary
 
 # Add the parent directory of "model" to the system path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 from model.evaluate import get_prediction
 
+# Adding a directory to store processed images
+processed_images_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "images")
+if not os.path.isdir(processed_images_path):
+    os.mkdir(processed_images_path)
+
+# Creating a directory to contain the model
+model_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "model")
+if not os.path.isdir(model_path):
+    os.mkdir(model_path)
 
 @app.route('/scan', methods=['POST'])
 def process_image():
@@ -35,7 +47,7 @@ def process_image():
         
         # Process the image and get classification
         # Needs to be changed in production
-        classification = get_prediction(image_dir, "/Users/ethanburgess/Downloads/best.pth")
+        classification = get_prediction(image_dir, os.path.join(model_path, f"{MODEL}"))
         print(f"Classification: {classification}")
         
         # Get suggestions from OpenAI based on classification
@@ -91,7 +103,7 @@ def convert_base64_jpg(base64_string):
 
     # Path where the image will be saved
     # Needs to be changed in production
-    temp_img_dir = f"/Users/ethanburgess/Desktop/UTS/sem22024/sis/SIS15/tempFiles/{image_id}.jpg"
+    temp_img_dir = os.path.join(processed_images_path, f"{image_id}.jpg")
     print(f"Saving image to: {temp_img_dir}")
 
     # Save the decoded image to a file
@@ -102,4 +114,4 @@ def convert_base64_jpg(base64_string):
 
 
 if __name__ == '__main__':
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    app.run(host="0.0.0.0", port=5001, debug=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,6 @@ SQLAlchemy==2.0.35
 typing_extensions==4.12.2
 Werkzeug==3.0.4
 openai==1.50.2
-pytorch==2.4.1
-clip==0.2.0
-torchvision==0.19.1
+torch==1.7.1
+torchvision==0.8.2
+clip-by-openai==1.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,7 @@ python-dotenv==1.0.1
 SQLAlchemy==2.0.35
 typing_extensions==4.12.2
 Werkzeug==3.0.4
+openai==1.50.2
+pytorch==2.4.1
+clip==0.2.0
+torchvision==0.19.1

--- a/frontend/api/scan/use-scan-item.ts
+++ b/frontend/api/scan/use-scan-item.ts
@@ -10,7 +10,7 @@ export const useScanItem = () => {
 
   const mutation = useMutation<ScannedItem, Error, ScanItemRequest>({
     mutationFn: async (json) => {
-      const response = await fetch(`${url}/mockScan`, {
+      const response = await fetch(`${url}/scan`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Previous implementation of `app.py` was utilising hardcoded file paths to save scanned images and reference the trained model. 

These changes do the following:

1. Check if `images/` exists in the `backend/` directory of the project and if it doesn't, create it
2. Scanned images are then sent to `backend/images/`
3. Path to the trained model is now in a constant variable called `MODEL` at the top of `app.py` and is expected to be placed in `backend/model`

`README` was also updated to have more detailed information on how to get the project up and running.